### PR TITLE
Generic code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.lightrail</groupId>
     <artifactId>lightrail-client</artifactId>
-    <version>4.1.0</version>
+    <version>4.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>lightrail-client</name>
     <description>A java client for the Lightrail API</description>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.lightrail</groupId>
     <artifactId>lightrail-client</artifactId>
-    <version>4.2.0-SNAPSHOT</version>
+    <version>4.2.0</version>
     <packaging>jar</packaging>
     <name>lightrail-client</name>
     <description>A java client for the Lightrail API</description>

--- a/src/main/java/com/lightrail/model/GenericCodeOptions.java
+++ b/src/main/java/com/lightrail/model/GenericCodeOptions.java
@@ -1,0 +1,13 @@
+package com.lightrail.model;
+
+public class GenericCodeOptions {
+
+    public PerContactGenericCodeOptions perContact;
+
+    public GenericCodeOptions() {
+    }
+
+    public GenericCodeOptions(PerContactGenericCodeOptions perContact) {
+        this.perContact = perContact;
+    }
+}

--- a/src/main/java/com/lightrail/model/PerContactGenericCodeOptions.java
+++ b/src/main/java/com/lightrail/model/PerContactGenericCodeOptions.java
@@ -1,0 +1,14 @@
+package com.lightrail.model;
+
+public class PerContactGenericCodeOptions {
+    public Integer balance;
+    public Integer usesRemaining;
+
+    public PerContactGenericCodeOptions() {
+    }
+
+    public PerContactGenericCodeOptions(Integer balance, Integer usesRemaining) {
+        this.balance = balance;
+        this.usesRemaining = usesRemaining;
+    }
+}

--- a/src/main/java/com/lightrail/model/Value.java
+++ b/src/main/java/com/lightrail/model/Value.java
@@ -14,6 +14,8 @@ public class Value {
     public String programId;
     public String code;
     public Boolean isGenericCode;
+    public String attachedFromValueId;
+    public GenericCodeOptions genericCodeOptions;
     public String contactId;
     public Boolean pretax;
     public Boolean active;
@@ -42,6 +44,8 @@ public class Value {
                 Objects.equals(programId, value.programId) &&
                 Objects.equals(code, value.code) &&
                 Objects.equals(isGenericCode, value.isGenericCode) &&
+                Objects.equals(attachedFromValueId, value.attachedFromValueId) &&
+                Objects.equals(genericCodeOptions, value.genericCodeOptions) &&
                 Objects.equals(contactId, value.contactId) &&
                 Objects.equals(pretax, value.pretax) &&
                 Objects.equals(active, value.active) &&

--- a/src/main/java/com/lightrail/params/values/CreateValueParams.java
+++ b/src/main/java/com/lightrail/params/values/CreateValueParams.java
@@ -1,6 +1,7 @@
 package com.lightrail.params.values;
 
 import com.lightrail.model.BalanceRule;
+import com.lightrail.model.GenericCodeOptions;
 import com.lightrail.model.RedemptionRule;
 
 import java.util.Date;
@@ -15,6 +16,7 @@ public class CreateValueParams {
     public String programId;
     public String code;
     public Boolean isGenericCode;
+    public GenericCodeOptions genericCodeOptions;
     public String contactId;
     public Boolean pretax;
     public Boolean active;

--- a/src/main/java/com/lightrail/params/values/ListValuesParams.java
+++ b/src/main/java/com/lightrail/params/values/ListValuesParams.java
@@ -13,6 +13,8 @@ public class ListValuesParams {
     public String contactId;
     public Integer balance;
     public Integer usesRemaining;
+    public Boolean isGenericCode;
+    public String attachedFromValueId;
     public Boolean discount;
     public Boolean pretax;
     public Boolean active;


### PR DESCRIPTION
This is a "first cut" update to support the new generic code functionality in the API. Adds support for: 
- Creating generic Values with `perContact` properties
- Including `attachedFromValueId` in Value responses
- Filtering Values by `attachedFromValueId` and by `isGenericCode`

Does not remove legacy functionality of `attachGenericAsNewValue`.